### PR TITLE
1，模板消息设置公众号所属行业传参数错误，不符合公众号要求

### DIFF
--- a/src/OfficialAccount/TemplateMsg.php
+++ b/src/OfficialAccount/TemplateMsg.php
@@ -92,6 +92,13 @@ class TemplateMsg extends OfficialAccountBase
             'ACCESS_TOKEN'=> $this->getOfficialAccount()->accessToken()->getToken()
         ]);
 
+
+        $data = [];
+
+        foreach ($industryId as $key => $value) {
+            $data['industry_id'.($key+1)] = $value;
+        }
+
         $response = NetWork::postJsonForJson($url, $industryId);
         $this->hasException($response);
         return true;


### PR DESCRIPTION
1，模板消息设置公众号所属行业传参数错误，不符合公众号要求